### PR TITLE
require-jsdoc: Class should not require jsdoc

### DIFF
--- a/eslintrc.json
+++ b/eslintrc.json
@@ -155,9 +155,9 @@
           "FunctionDeclaration": true,
           "FunctionExpression": true,
           "MethodDefinition": true,
-          "ClassExpression": true,
-          "ClassDeclaration": true
-          }
+          "ClassExpression": false,
+          "ClassDeclaration": false
+        }
       }
     ],
     "jsdoc/require-property": "error",


### PR DESCRIPTION
The requirement of a jsdoc annotation on a class
leads to a lot of useless annotations like

```js
/** @class */
class SyscallError extends WError {}
```

All of the annotations on the class block so far are just
to say it is a `@class` which is redundant.