### PR TITLE
add no-async-promise-executor

### DIFF
--- a/eslintrc.json
+++ b/eslintrc.json
@@ -29,6 +29,7 @@
     "@typescript-eslint/default-param-last": ["error"],
 
     "no-return-await": "error",
+    "no-async-promise-executor": "error",
 
     "@typescript-eslint/adjacent-overload-signatures": "error",
     "@typescript-eslint/array-type": "error",


### PR DESCRIPTION
This is a good rule to default too.

This rule was recently defaulted to "error" in deno.