### PR TITLE
require-jsdoc: Enable exemptEmptyFunction

### DIFF
--- a/eslintrc.json
+++ b/eslintrc.json
@@ -152,6 +152,7 @@
       "error",
       {
         "publicOnly": false,
+        "exemptEmptyFunctions": true,
         "require": {
           "FunctionDeclaration": true,
           "FunctionExpression": true,


### PR DESCRIPTION
There are cases like `constructor() { this.foo = null }` where
a function does not require a jsdoc block.

In this case the constructor is known to statically always
return `void` and it has zero parameters.

Most other functions need a `@returns` annotation but the
constructor CANNOT return anything.