### PR TITLE
config: Disable eslint no-useless-constructor

### DIFF
--- a/eslintrc.json
+++ b/eslintrc.json
@@ -28,6 +28,9 @@
     "default-param-last": "off",
     "@typescript-eslint/default-param-last": ["error"],
 
+    "no-useless-constructor": "off",
+    "@typescript-eslint/no-useless-constructor": ["error"],
+
     "no-return-await": "error",
     "no-async-promise-executor": "error",
 


### PR DESCRIPTION
This does not understand typescript and we must use the
@typescript-eslint/no-useless-constructor instead.