### PR TITLE
src: Disable unified-signatures

### DIFF
--- a/eslintrc.json
+++ b/eslintrc.json
@@ -156,7 +156,7 @@
     "@typescript-eslint/type-annotation-spacing": "error",
     "@typescript-eslint/typedef": "off",
     "@typescript-eslint/unbound-method": "off",
-    "@typescript-eslint/unified-signatures": "error",
+    "@typescript-eslint/unified-signatures": "off",
 
     "jsdoc-typescript/require-constructor-property": "error",
 


### PR DESCRIPTION
This trusn off the unified signatures error. There are lots
of cases where this feels like bikeshedding instead of catching
an actual type error.

For example

```
connect(port: number) => void
connect(path: string) => void
// Versus
connect(options: number | string) => void
```

The rule wants the latter, but the former with manually written
method overloads seems like a better way to document the
signature due to the information in the parameter name.